### PR TITLE
Setup docker network environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ First go to the root of the application
 cd <projet-location>/mole
 ```
 
+Create a network for the _mole_ local environment
+
+```
+docker network create -d bridge mole-local-network
+```
+
+> We need both environments to use the same network to be able to create a tunnel to each other.
+
 To run the mole client, run;
 
 ```

--- a/docker/dev/client/docker-compose.yml
+++ b/docker/dev/client/docker-compose.yml
@@ -12,3 +12,7 @@ services:
       - ../../../client/.env
     environment:
       PORT: 8080
+networks:
+  default:
+    external:
+      name: mole-local-network

--- a/docker/dev/server/docker-compose.yml
+++ b/docker/dev/server/docker-compose.yml
@@ -12,3 +12,7 @@ services:
       - ../../../server/.env
     environment:
       PORT: 5000
+networks:
+  default:
+    external:
+      name: mole-local-network


### PR DESCRIPTION
**What does this PR do**
This PR setups a local network for the various docker environments for the mole project.

**Description of tasks to be completed**
The PR connects both the server and client service to the `mole-local-environment` and thus make use of the internal docker DNS resolver to reach each other.

**How should this be manually tested?**
- Follow the instructions on the README.md file
- Run the command `make server-ssh`
- Run the command `ping client` in the `server` docker environment

**More information**
This PR assumes that one has created the network locally before running the respective `docker` commands.